### PR TITLE
fix call to python module

### DIFF
--- a/qml/sailfish-python.qml
+++ b/qml/sailfish-python.qml
@@ -16,7 +16,7 @@ ApplicationWindow {
                 py.addImportPath(Qt.resolvedUrl('../src/pyPackages/pillow-i686'));
             }
             py.importModule('main',function(){
-            py.call("helloworld",[])
+            py.call("main.helloWorld",[])
             pageStack.push(Qt.resolvedUrl("Main.qml"))
             })
         }


### PR DESCRIPTION
Before fix, this error messages showed up in Sailfish Emulator:

``` bash
[D] QPythonPriv::formatExc:612 - "PyOtherSide error: Traceback (most recent call last):

  File "<string>", line 1, in <module>

NameError: name 'helloworld' is not defined
" 
[W] QPython::emitError:380 - Unhandled PyOtherSide error: Function not found: 'helloworld' (Traceback (most recent call last):

  File "<string>", line 1, in <module>

NameError: name 'helloworld' is not defined
)
^C
```
